### PR TITLE
Fix server-side validation errors not displaying on forms

### DIFF
--- a/src/Controller/Admin/ManagerController.php
+++ b/src/Controller/Admin/ManagerController.php
@@ -11,15 +11,18 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use App\Traits\FormValidationTrait;
 
 #[Route('/admin/managers')]
 class ManagerController extends AbstractController
 {
+    use FormValidationTrait;
+
     #[Route('', name: 'app_admin_managers')]
     public function index(ManagerRepository $repo): Response
     {
         return $this->render('admin/managers/index.html.twig', [
-            'managers' => $repo->findAll(),
+            'managers' => $repo->findNonAdmins(),
         ]);
     }
 
@@ -31,39 +34,92 @@ class ManagerController extends AbstractController
         UserPasswordHasherInterface $hasher
     ): Response {
         $manager = new Manager();
+        $errors = [];
+        $old    = [];
+
+        // dd('ADD', $request->getMethod());
+
+        // dump('method: ' . $request->getMethod());
 
         if ($request->isMethod('POST')) {
-            $manager->setFirstName($request->request->get('first_name'));
-            $manager->setLastName($request->request->get('last_name'));
-            $manager->setEmail($request->request->get('email'));
-            $manager->setCreatedAt(new \DateTime());
-
-            $roles = $request->request->get('role') === 'ROLE_ADMIN'
-                ? ['ROLE_ADMIN']
-                : ['ROLE_USER'];
-            $manager->setRoles($roles);
-
-            $plainPassword = $request->request->get('password');
-            $manager->setPassword($hasher->hashPassword($manager, $plainPassword));
-
+            // dump('entered POST block');
+            $firstName = trim($request->request->get('first_name') ?? '');
+            $lastName  = trim($request->request->get('last_name') ?? '');
+            $email     = trim($request->request->get('email') ?? '');
+            $password  = $request->request->get('password') ?? '';
             $companyId = $request->request->get('company_id');
-            $manager->setCompany($companyId ? $companyRepo->find($companyId) : null);
+            $role      = $request->request->get('role');
 
-            $em->persist($manager);
-            $em->flush();
+            $old = [
+                'first_name' => $firstName,
+                'last_name'  => $lastName,
+                'email'      => $email,
+                'role'       => $role,
+                'company_id' => $companyId,
+            ];
 
-            $this->addFlash('success', 'Manager added successfully.');
-            return $this->redirectToRoute('app_admin_managers');
+            $this->clearValidationErrors();
+
+            $this->validateName($firstName, 'First name', true);
+            if ($this->hasValidationErrors()) {
+                $errors['first_name'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            $this->validateName($lastName, 'Last name', true);
+            if ($this->hasValidationErrors()) {
+                $errors['last_name'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            // dd($errors);
+
+            $this->validateEmail($email, 'Email', true);
+            if ($this->hasValidationErrors()) {
+                $errors['email'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            if (!isset($errors['email'])) {
+                $existing = $em->getRepository(Manager::class)->findOneBy(['email' => $email]);
+                if ($existing) {
+                    $errors['email'] = 'This email address is already in use.';
+                }
+            }
+
+            $this->validatePassword($password, true);
+            if ($this->hasValidationErrors()) {
+                $errors['password'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            if (empty($errors)) {
+                $manager->setFirstName($firstName);
+                $manager->setLastName($lastName);
+                $manager->setEmail($email);
+                $manager->setRoles($role === 'ROLE_ADMIN' ? ['ROLE_ADMIN'] : ['ROLE_USER']);
+                $manager->setPassword($hasher->hashPassword($manager, $password));
+                $manager->setCreatedAt(new \DateTime());
+                $manager->setCompany($companyId ? $companyRepo->find($companyId) : null);
+
+                $em->persist($manager);
+                $em->flush();
+
+                $this->addFlash('success', 'Manager added successfully.');
+                return $this->redirectToRoute('app_admin_managers');
+            }
         }
 
         return $this->render('admin/managers/form.html.twig', [
             'manager'   => $manager,
             'companies' => $companyRepo->findAll(),
             'mode'      => 'add',
+            'errors'    => $errors,
+            'old'       => $old,
         ]);
     }
 
-    #[Route('/edit/{id}', name: 'app_admin_managers_edit')]
+    #[Route('/edit/{id}', name: 'app_admin_managers_edit', requirements: ['id' => '\d+'])]
     public function edit(
         Manager $manager,
         Request $request,
@@ -71,39 +127,92 @@ class ManagerController extends AbstractController
         CompanyRepository $companyRepo,
         UserPasswordHasherInterface $hasher
     ): Response {
+        $errors = [];
+        $old    = [];
+
+        // dd('EDIT', $request->getMethod(), $manager->getId());
+
         if ($request->isMethod('POST')) {
-            $manager->setFirstName($request->request->get('first_name'));
-            $manager->setLastName($request->request->get('last_name'));
-            $manager->setEmail($request->request->get('email'));
-
-            $roles = $request->request->get('role') === 'ROLE_ADMIN'
-                ? ['ROLE_ADMIN']
-                : ['ROLE_USER'];
-            $manager->setRoles($roles);
-
+            $firstName = trim($request->request->get('first_name') ?? '');
+            $lastName  = trim($request->request->get('last_name') ?? '');
+            $email     = trim($request->request->get('email') ?? '');
+            $password  = $request->request->get('password') ?? '';
             $companyId = $request->request->get('company_id');
-            $manager->setCompany($companyId ? $companyRepo->find($companyId) : null);
+            $role      = $request->request->get('role');
 
-            // Only update password if a new one was provided
-            $plainPassword = $request->request->get('password');
-            if ($plainPassword) {
-                $manager->setPassword($hasher->hashPassword($manager, $plainPassword));
+            $old = [
+                'first_name' => $firstName,
+                'last_name'  => $lastName,
+                'email'      => $email,
+                'role'       => $role,
+                'company_id' => $companyId,
+            ];
+
+            $this->clearValidationErrors();
+
+            $this->validateName($firstName, 'First name', true);
+            if ($this->hasValidationErrors()) {
+                $errors['first_name'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
             }
 
-            $em->flush();
+            $this->validateName($lastName, 'Last name', true);
+            if ($this->hasValidationErrors()) {
+                $errors['last_name'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
 
-            $this->addFlash('success', 'Manager updated successfully.');
-            return $this->redirectToRoute('app_admin_managers');
+            $this->validateEmail($email, 'Email', true);
+            if ($this->hasValidationErrors()) {
+                $errors['email'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            // Exclude the current manager from the duplicate check
+            if (!isset($errors['email'])) {
+                $existing = $em->getRepository(Manager::class)->findOneBy(['email' => $email]);
+                if ($existing && $existing->getId() !== $manager->getId()) {
+                    $errors['email'] = 'This email address is already in use.';
+                }
+            }
+
+            // Password is optional on edit — only validate if provided
+            if ($password !== '') {
+                $this->validatePassword($password, false);
+                if ($this->hasValidationErrors()) {
+                    $errors['password'] = $this->getFirstValidationError();
+                    $this->clearValidationErrors();
+                }
+            }
+
+            if (empty($errors)) {
+                $manager->setFirstName($firstName);
+                $manager->setLastName($lastName);
+                $manager->setEmail($email);
+                $manager->setRoles($role === 'ROLE_ADMIN' ? ['ROLE_ADMIN'] : ['ROLE_USER']);
+                $manager->setCompany($companyId ? $companyRepo->find($companyId) : null);
+
+                if ($password !== '') {
+                    $manager->setPassword($hasher->hashPassword($manager, $password));
+                }
+
+                $em->flush();
+
+                $this->addFlash('success', 'Manager updated successfully.');
+                return $this->redirectToRoute('app_admin_managers');
+            }
         }
 
         return $this->render('admin/managers/form.html.twig', [
             'manager'   => $manager,
             'companies' => $companyRepo->findAll(),
             'mode'      => 'edit',
+            'errors'    => $errors,
+            'old'       => $old,
         ]);
     }
 
-    #[Route('/delete/{id}', name: 'app_admin_managers_delete', methods: ['POST'])]
+    #[Route('/delete/{id}', name: 'app_admin_managers_delete', methods: ['POST'], requirements: ['id' => '\d+'])]
     public function delete(Manager $manager, EntityManagerInterface $em): Response
     {
         $em->remove($manager);

--- a/src/Controller/Admin/ProductCategoryController.php
+++ b/src/Controller/Admin/ProductCategoryController.php
@@ -9,10 +9,13 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use App\Traits\FormValidationTrait;
 
 #[Route('/admin/product-categories')]
 class ProductCategoryController extends AbstractController
 {
+    use FormValidationTrait;
+
     #[Route('', name: 'app_admin_product_categories')]
     public function index(ProductCategoryRepository $repo): Response
     {
@@ -25,42 +28,108 @@ class ProductCategoryController extends AbstractController
     public function add(Request $request, EntityManagerInterface $em): Response
     {
         $category = new ProductCategory();
+        $errors   = [];
+        $old      = [];
 
         if ($request->isMethod('POST')) {
-            $category->setName($request->request->get('name'));
-            $category->setDescription($request->request->get('description'));
-            $category->setSlug($request->request->get('slug'));
+            $name        = trim($request->request->get('name') ?? '');
+            $slug        = trim($request->request->get('slug') ?? '');
+            $description = trim($request->request->get('description') ?? '');
 
-            $em->persist($category);
-            $em->flush();
+            $old = compact('name', 'slug', 'description');
 
-            $this->addFlash('success', 'Category added successfully.');
-            return $this->redirectToRoute('app_admin_product_categories');
+            $this->clearValidationErrors();
+
+            $this->validateName($name, 'Name', true);
+            if ($this->hasValidationErrors()) {
+                $errors['name'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            $this->validateAlphanumeric($slug, 'Slug', true);
+            if ($this->hasValidationErrors()) {
+                $errors['slug'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            $this->validateRequired($description, 'Description', 10);
+            if ($this->hasValidationErrors()) {
+                $errors['description'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            if (empty($errors)) {
+                $category->setName($name);
+                $category->setSlug($slug);
+                $category->setDescription($description);
+
+                $em->persist($category);
+                $em->flush();
+
+                $this->addFlash('success', 'Category added successfully.');
+                return $this->redirectToRoute('app_admin_product_categories');
+            }
         }
 
         return $this->render('admin/product_categories/form.html.twig', [
             'category' => $category,
-            'mode' => 'add',
+            'mode'     => 'add',
+            'errors'   => $errors,
+            'old'      => $old,
         ]);
     }
 
     #[Route('/edit/{id}', name: 'app_admin_product_categories_edit')]
     public function edit(ProductCategory $category, Request $request, EntityManagerInterface $em): Response
     {
+        $errors = [];
+        $old    = [];
+        
+
         if ($request->isMethod('POST')) {
-            $category->setName($request->request->get('name'));
-            $category->setDescription($request->request->get('description'));
-            $category->setSlug($request->request->get('slug'));
+            $name        = trim($request->request->get('name') ?? '');
+            $slug        = trim($request->request->get('slug') ?? '');
+            $description = trim($request->request->get('description') ?? '');
 
-            $em->flush();
+            $old = compact('name', 'slug', 'description');
 
-            $this->addFlash('success', 'Category updated successfully.');
-            return $this->redirectToRoute('app_admin_product_categories');
+            $this->clearValidationErrors();
+
+            $this->validateName($name, 'Name', true);
+            if ($this->hasValidationErrors()) {
+                $errors['name'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            $this->validateAlphanumeric($slug, 'Slug', true);
+            if ($this->hasValidationErrors()) {
+                $errors['slug'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            $this->validateRequired($description, 'Description', 10);
+            if ($this->hasValidationErrors()) {
+                $errors['description'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            if (empty($errors)) {
+                $category->setName($name);
+                $category->setSlug($slug);
+                $category->setDescription($description);
+
+                $em->flush();
+
+                $this->addFlash('success', 'Category updated successfully.');
+                return $this->redirectToRoute('app_admin_product_categories');
+            }
         }
 
         return $this->render('admin/product_categories/form.html.twig', [
             'category' => $category,
-            'mode' => 'edit',
+            'mode'     => 'edit',
+            'errors'   => $errors,
+            'old'      => $old,
         ]);
     }
 

--- a/src/Controller/Admin/ProfileController.php
+++ b/src/Controller/Admin/ProfileController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Controller\Admin;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use App\Traits\FormValidationTrait;
+
+#[Route('/admin/profile')]
+class ProfileController extends AbstractController
+{
+    use FormValidationTrait;
+
+    #[Route('', name: 'app_admin_profile')]
+    public function index(Request $request, EntityManagerInterface $em): Response
+    {
+        $manager = $this->getUser();
+        $errors  = [];
+        $success = null;
+
+        if ($request->isMethod('POST')) {
+            $firstName = trim($request->request->get('first_name') ?? '');
+            $lastName  = trim($request->request->get('last_name') ?? '');
+            $email     = trim($request->request->get('email') ?? '');
+
+            $this->clearValidationErrors();
+
+            $this->validateName($firstName, 'First name', true);
+            if ($this->hasValidationErrors()) {
+                $errors['first_name'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            $this->validateName($lastName, 'Last name', true);
+            if ($this->hasValidationErrors()) {
+                $errors['last_name'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            $this->validateEmail($email, 'Email', true);
+            if ($this->hasValidationErrors()) {
+                $errors['email'] = $this->getFirstValidationError();
+                $this->clearValidationErrors();
+            }
+
+            if (!isset($errors['email']) && $email !== $manager->getEmail()) {
+                $existing = $em->getRepository(\App\Entity\Manager::class)->findOneBy(['email' => $email]);
+                if ($existing && $existing->getId() !== $manager->getId()) {
+                    $errors['email'] = 'This email address is already in use.';
+                }
+            }
+
+            if (empty($errors)) {
+                $manager->setFirstName($firstName);
+                $manager->setLastName($lastName);
+                $manager->setEmail($email);
+                $em->flush();
+                $success = 'Profile updated successfully.';
+            }
+        }
+
+        return $this->render('admin/profile/index.html.twig', [
+            'manager' => $manager,
+            'errors'  => $errors,
+            'success' => $success,
+        ]);
+    }
+}

--- a/src/Traits/FormValidationTrait.php
+++ b/src/Traits/FormValidationTrait.php
@@ -1,0 +1,384 @@
+<?php
+
+namespace App\Traits;
+
+/**
+ * Trait FormValidationTrait
+ * 
+ * Provides server-side validation methods for form inputs
+ */
+trait FormValidationTrait
+{
+    /**
+     * Validation errors array
+     */
+    protected array $validationErrors = [];
+
+    /**
+     * Validate a name field (letters, spaces, hyphens, apostrophes only)
+     */
+    protected function validateName(?string $value, string $fieldName, bool $required = false): bool
+    {
+        if (empty($value)) {
+            if ($required) {
+                $this->validationErrors[] = ucfirst($fieldName) . ' is required.';
+                return false;
+            }
+            return true;
+        }
+
+        $value = trim($value);
+        
+        if (!preg_match('/^[a-zA-Z\s\'-]+$/', $value)) {
+            $this->validationErrors[] = ucfirst($fieldName) . ' must contain only letters, spaces, hyphens, and apostrophes.';
+            return false;
+        }
+
+        if (strlen($value) < 2) {
+            $this->validationErrors[] = ucfirst($fieldName) . ' must be at least 2 characters long.';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate an email address
+     */
+    protected function validateEmail(?string $value, string $fieldName = 'Email', bool $required = false): bool
+    {
+        if (empty($value)) {
+            if ($required) {
+                $this->validationErrors[] = $fieldName . ' is required.';
+                return false;
+            }
+            return true;
+        }
+
+        $value = trim($value);
+
+        if (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            $this->validationErrors[] = 'Please enter a valid ' . strtolower($fieldName) . ' address.';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate a password
+     */
+    protected function validatePassword(?string $value, bool $required = false, int $minLength = 8): bool
+    {
+        if (empty($value)) {
+            if ($required) {
+                $this->validationErrors[] = 'Password is required.';
+                return false;
+            }
+            return true;
+        }
+
+        if (strlen($value) < $minLength) {
+            $this->validationErrors[] = 'Password must be at least ' . $minLength . ' characters long.';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate password confirmation matches
+     */
+    protected function validatePasswordMatch(?string $password, ?string $confirmPassword): bool
+    {
+        if (empty($password) && empty($confirmPassword)) {
+            return true;
+        }
+
+        if ($password !== $confirmPassword) {
+            $this->validationErrors[] = 'Passwords do not match.';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate a country code (2-5 uppercase letters)
+     */
+    protected function validateCountryCode(?string $value, bool $required = false): bool
+    {
+        if (empty($value)) {
+            if ($required) {
+                $this->validationErrors[] = 'Country code is required.';
+                return false;
+            }
+            return true;
+        }
+
+        $value = strtoupper(trim($value));
+
+        if (!preg_match('/^[A-Z]{2,5}$/', $value)) {
+            $this->validationErrors[] = 'Country code must be 2-5 uppercase letters (e.g., FR, DE, IT).';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate an HS Code (Harmonized System code)
+     */
+    protected function validateHsCode(?string $value, bool $required = false): bool
+    {
+        if (empty($value)) {
+            if ($required) {
+                $this->validationErrors[] = 'HS Code is required.';
+                return false;
+            }
+            return true;
+        }
+
+        $value = trim($value);
+
+        if (!preg_match('/^[\d\.]{4,10}$/', $value)) {
+            $this->validationErrors[] = 'HS Code must be 4-10 digits (e.g., 6109.10).';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate a phone number
+     */
+    protected function validatePhone(?string $value, bool $required = false): bool
+    {
+        if (empty($value)) {
+            if ($required) {
+                $this->validationErrors[] = 'Phone number is required.';
+                return false;
+            }
+            return true;
+        }
+
+        $value = trim($value);
+
+        if (!preg_match('/^[\d\s\+\-\(\)]+$/', $value)) {
+            $this->validationErrors[] = 'Please enter a valid phone number.';
+            return false;
+        }
+
+        if (strlen(preg_replace('/\D/', '', $value)) < 7) {
+            $this->validationErrors[] = 'Phone number must have at least 7 digits.';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate a URL
+     */
+    protected function validateUrl(?string $value, bool $required = false): bool
+    {
+        if (empty($value)) {
+            if ($required) {
+                $this->validationErrors[] = 'URL is required.';
+                return false;
+            }
+            return true;
+        }
+
+        $value = trim($value);
+
+        if (!preg_match('/^https?:\/\//', $value)) {
+            $this->validationErrors[] = 'URL must start with http:// or https://.';
+            return false;
+        }
+
+        if (!filter_var($value, FILTER_VALIDATE_URL)) {
+            $this->validationErrors[] = 'Please enter a valid URL.';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate alphanumeric input
+     */
+    protected function validateAlphanumeric(?string $value, string $fieldName, bool $required = false): bool
+    {
+        if (empty($value)) {
+            if ($required) {
+                $this->validationErrors[] = ucfirst($fieldName) . ' is required.';
+                return false;
+            }
+            return true;
+        }
+
+        $value = trim($value);
+
+        if (!preg_match('/^[a-zA-Z0-9\s]+$/', $value)) {
+            $this->validationErrors[] = ucfirst($fieldName) . ' must contain only letters and numbers.';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate a number
+     */
+    protected function validateNumber($value, string $fieldName, bool $required = false, ?float $min = null, ?float $max = null): bool
+    {
+        if ($value === null || $value === '') {
+            if ($required) {
+                $this->validationErrors[] = ucfirst($fieldName) . ' is required.';
+                return false;
+            }
+            return true;
+        }
+
+        if (!is_numeric($value)) {
+            $this->validationErrors[] = ucfirst($fieldName) . ' must be a valid number.';
+            return false;
+        }
+
+        $numValue = (float) $value;
+
+        if ($min !== null && $numValue < $min) {
+            $this->validationErrors[] = ucfirst($fieldName) . ' must be at least ' . $min . '.';
+            return false;
+        }
+
+        if ($max !== null && $numValue > $max) {
+            $this->validationErrors[] = ucfirst($fieldName) . ' must not exceed ' . $max . '.';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate a required field (generic string)
+     */
+    protected function validateRequired(?string $value, string $fieldName, int $minLength = 1, ?int $maxLength = null): bool
+    {
+        if (empty($value)) {
+            $this->validationErrors[] = ucfirst($fieldName) . ' is required.';
+            return false;
+        }
+
+        $value = trim($value);
+
+        if (strlen($value) < $minLength) {
+            $this->validationErrors[] = ucfirst($fieldName) . ' must be at least ' . $minLength . ' characters long.';
+            return false;
+        }
+
+        if ($maxLength !== null && strlen($value) > $maxLength) {
+            $this->validationErrors[] = ucfirst($fieldName) . ' must not exceed ' . $maxLength . ' characters.';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate a date
+     */
+    protected function validateDate(?string $value, string $fieldName, bool $required = false): bool
+    {
+        if (empty($value)) {
+            if ($required) {
+                $this->validationErrors[] = ucfirst($fieldName) . ' is required.';
+                return false;
+            }
+            return true;
+        }
+
+        $date = \DateTime::createFromFormat('Y-m-d', $value);
+
+        if (!$date || $date->format('Y-m-d') !== $value) {
+            $this->validationErrors[] = ucfirst($fieldName) . ' must be a valid date (YYYY-MM-DD).';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate that end date is after start date
+     */
+    protected function validateDateRange(?string $startDate, ?string $endDate): bool
+    {
+        if (empty($startDate) || empty($endDate)) {
+            return true;
+        }
+
+        $start = new \DateTime($startDate);
+        $end = new \DateTime($endDate);
+
+        if ($end < $start) {
+            $this->validationErrors[] = 'End date must be after start date.';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate a selection (dropdown/radio)
+     */
+    protected function validateSelection(?string $value, array $allowedOptions, string $fieldName, bool $required = false): bool
+    {
+        if (empty($value)) {
+            if ($required) {
+                $this->validationErrors[] = ucfirst($fieldName) . ' is required.';
+                return false;
+            }
+            return true;
+        }
+
+        if (!in_array($value, $allowedOptions)) {
+            $this->validationErrors[] = 'Please select a valid ' . strtolower($fieldName) . '.';
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get all validation errors
+     */
+    protected function getValidationErrors(): array
+    {
+        return $this->validationErrors;
+    }
+
+    /**
+     * Check if there are any validation errors
+     */
+    protected function hasValidationErrors(): bool
+    {
+        return !empty($this->validationErrors);
+    }
+
+    /**
+     * Clear validation errors
+     */
+    protected function clearValidationErrors(): void
+    {
+        $this->validationErrors = [];
+    }
+
+    /**
+     * Get first validation error (for backward compatibility)
+     */
+    protected function getFirstValidationError(): ?string
+    {
+        return $this->validationErrors[0] ?? null;
+    }
+}

--- a/templates/admin/managers/form.html.twig
+++ b/templates/admin/managers/form.html.twig
@@ -1,9 +1,7 @@
 {% extends 'admin/base_admin.html.twig' %}
-
 {% block title %}{{ mode == 'edit' ? 'Edit' : 'Add' }} Manager - ExportBridge Admin{% endblock %}
 
 {% block admin_content %}
-
     <div class="row mb-3">
         <div class="col-12 d-sm-flex justify-content-between align-items-center">
             <h1 class="h3 mb-2 mb-sm-0">
@@ -16,65 +14,94 @@
     </div>
 
     <div class="card shadow">
-        <div class="card-header border-bottom">
-            <h5 class="card-header-title">Manager Information</h5>
+        {# Role button — sits in the card header row alongside a title, full width row #}
+        <div class="col-12 d-flex justify-content-between align-items-center px-4 pt-2">
+            <h6 class="mb-0 text-muted">Manager Details</h6>
+            <div class="d-flex align-items-center gap-2">
+                <input type="hidden" name="role" id="roleInput"
+                    value="{{ old.role ?? ('ROLE_ADMIN' in manager.roles ? 'ROLE_ADMIN' : 'ROLE_USER') }}">
+                <small id="roleStatus" class="text-muted"></small>
+                <button type="button" id="elevateBtn" class="btn btn-outline-warning btn-sm">
+                    <i class="bi bi-shield-lock me-1"></i>
+                    <span id="elevateBtnLabel">Elevate to Admin</span>
+                </button>
+            </div>
         </div>
         <div class="card-body">
-            <form action="" method="post" class="row g-4">
-
+            <form action="{{ mode == 'edit' ? path('app_admin_managers_edit', {id: manager.id}) : path('app_admin_managers_add') }}" method="post" class="row g-4" > 
+                {# First Name #}
                 <div class="col-lg-6">
                     <label class="form-label">First Name *</label>
-                    <input type="text" name="first_name" class="form-control"
-                           value="{{ manager.firstName ?? '' }}" required>
+                    <input type="text" name="first_name"
+                           class="form-control {{ errors.first_name is defined ? 'is-invalid' : '' }}"
+                           value="{{ old.first_name ?? manager.firstName ?? '' }}" required>
+                    {% if errors.first_name is defined %}
+                        <div class="invalid-feedback d-block">{{ errors.first_name }}</div>
+                    {% endif %}
                 </div>
 
+                {# Last Name #}
                 <div class="col-lg-6">
                     <label class="form-label">Last Name *</label>
-                    <input type="text" name="last_name" class="form-control"
-                           value="{{ manager.lastName ?? '' }}" required>
+                    <input type="text" name="last_name"
+                           class="form-control {{ errors.last_name is defined ? 'is-invalid' : '' }}"
+                           value="{{ old.last_name ?? manager.lastName ?? '' }}" required>
+                    {% if errors.last_name is defined %}
+                        <div class="invalid-feedback d-block">{{ errors.last_name }}</div>
+                    {% endif %}
                 </div>
 
+                {# Email #}
                 <div class="col-lg-6">
                     <label class="form-label">Email *</label>
-                    <input type="email" name="email" class="form-control"
-                           value="{{ manager.email ?? '' }}" required>
+                    <input type="email" name="email"
+                           class="form-control {{ errors.email is defined ? 'is-invalid' : '' }}"
+                           value="{{ old.email ?? manager.email ?? '' }}" required>
+                    {% if errors.email is defined %}
+                        <div class="invalid-feedback d-block">{{ errors.email }}</div>
+                    {% endif %}
                 </div>
 
+                {# Company #}
                 <div class="col-lg-6">
                     <label class="form-label">Company</label>
                     <select name="company_id" class="form-select">
                         <option value="">— No Company —</option>
                         {% for company in companies %}
                             <option value="{{ company.id }}"
-                                {{ manager.company and manager.company.id == company.id ? 'selected' : '' }}>
+                                {{ (old.company_id ?? manager.company.id ?? '') == company.id ? 'selected' : '' }}>
                                 {{ company.companyName }}
                             </option>
                         {% endfor %}
                     </select>
                 </div>
 
-                <div class="col-lg-6">
-                    <label class="form-label">Role *</label>
-                    <select name="role" class="form-select" required>
-                        <option value="ROLE_USER"
-                            {{ 'ROLE_ADMIN' not in manager.roles ? 'selected' : '' }}>
-                            User
-                        </option>
-                        <option value="ROLE_ADMIN"
-                            {{ 'ROLE_ADMIN' in manager.roles ? 'selected' : '' }}>
-                            Admin
-                        </option>
-                    </select>
-                </div>
-
-                <div class="col-lg-6">
+                {# Password #}
+                <div class="col-12">
                     <label class="form-label">
                         Password {{ mode == 'edit' ? '(leave blank to keep current)' : '*' }}
                     </label>
-                    <input type="password" name="password" class="form-control"
-                           {{ mode == 'add' ? 'required' : '' }}>
+                    <div class="input-group {{ errors.password is defined ? 'is-invalid' : '' }}">
+                        <input type="text" id="passwordField" name="password"
+                            class="form-control {{ errors.password is defined ? 'is-invalid' : '' }}"
+                            {{ mode == 'add' ? 'required' : '' }}
+                            value="{{ old.password ?? '' }}"
+                            autocomplete="new-password">
+                        <button type="button" class="btn btn-outline-secondary" id="togglePasswordVisibility" title="Show/hide password">
+                            <i class="bi bi-eye" id="eyeIcon"></i>
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary" id="regenPassword" title="Generate new password">
+                            <i class="bi bi-arrow-clockwise"></i>
+                        </button>
+                    </div>
+                    {% if errors.password is defined %}
+                        <div class="invalid-feedback d-block">{{ errors.password }}</div>
+                    {% else %}
+                        <small class="text-muted">Auto-generated. Click <i class="bi bi-arrow-clockwise"></i> to regenerate.</small>
+                    {% endif %}
                 </div>
 
+                {# Submit #}
                 <div class="d-sm-flex justify-content-end">
                     <button type="submit" class="btn btn-primary mb-0">
                         {{ mode == 'edit' ? 'Save Changes' : 'Add Manager' }}
@@ -85,4 +112,69 @@
         </div>
     </div>
 
+    <script>
+    (function () {
+        // --- Password generation ---
+        function generatePassword(length = 14) {
+            const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@#$%&*';
+            return Array.from(crypto.getRandomValues(new Uint8Array(length)))
+                .map(b => chars[b % chars.length])
+                .join('');
+        }
+
+        const passwordField = document.getElementById('passwordField');
+        const eyeIcon       = document.getElementById('eyeIcon');
+        const toggleBtn     = document.getElementById('togglePasswordVisibility');
+        const regenBtn      = document.getElementById('regenPassword');
+
+        // Auto-fill on add mode
+        {% if mode == 'add' %}
+            if (!passwordField.value) {
+                passwordField.value = generatePassword();
+            }
+        {% endif %}
+
+        // Toggle visibility
+        passwordField.type = 'text'; // start visible
+        toggleBtn.addEventListener('click', function () {
+            const isText = passwordField.type === 'text';
+            passwordField.type = isText ? 'password' : 'text';
+            eyeIcon.className  = isText ? 'bi bi-eye-slash' : 'bi bi-eye';
+        });
+
+        // Regenerate
+        regenBtn.addEventListener('click', function () {
+            passwordField.value = generatePassword();
+            passwordField.type  = 'text';
+            eyeIcon.className   = 'bi bi-eye';
+        });
+
+        // --- Role toggle ---
+        const roleInput  = document.getElementById('roleInput');
+        const elevateBtn = document.getElementById('elevateBtn');
+        const roleStatus = document.getElementById('roleStatus');
+
+        function updateRoleUI(role) {
+            if (role === 'ROLE_ADMIN') {
+                elevateBtn.classList.replace('btn-outline-warning', 'btn-outline-danger');
+                elevateBtn.querySelector('#elevateBtnLabel').textContent = 'Revoke Admin';
+                elevateBtn.querySelector('i').className = 'bi bi-shield-x me-1';
+                roleStatus.textContent = 'Currently: Admin';
+            } else {
+                elevateBtn.classList.replace('btn-outline-danger', 'btn-outline-warning');
+                elevateBtn.querySelector('#elevateBtnLabel').textContent = 'Elevate to Admin';
+                elevateBtn.querySelector('i').className = 'bi bi-shield-lock me-1';
+                roleStatus.textContent = 'Currently: User';
+            }
+        }
+
+        updateRoleUI(roleInput.value); // init on page load
+
+        elevateBtn.addEventListener('click', function () {
+            const next = roleInput.value === 'ROLE_ADMIN' ? 'ROLE_USER' : 'ROLE_ADMIN';
+            roleInput.value = next;
+            updateRoleUI(next);
+        });
+    })();
+    </script>
 {% endblock %}

--- a/templates/admin/profile/index.html.twig
+++ b/templates/admin/profile/index.html.twig
@@ -1,0 +1,99 @@
+{% extends 'admin/base_admin.html.twig' %}
+
+{% block title %}My Profile - ExportBridge Admin{% endblock %}
+
+{% block admin_content %}
+
+    <div class="row mb-3">
+        <div class="col-12">
+            <h1 class="h3 mb-0">My Profile</h1>
+        </div>
+    </div>
+
+    <div class="row g-4">
+
+        {# Left — avatar and info summary #}
+        <div class="col-lg-4">
+            <div class="card shadow-sm text-center p-4">
+                <div class="avatar avatar-xxl mx-auto mb-3">
+                    <img class="avatar-img rounded-circle border border-white border-3 shadow"
+                         src="{{ asset('assets/images/avatar/01.jpg') }}" alt="avatar">
+                </div>
+                <h5 class="mb-1">{{ manager.firstName }} {{ manager.lastName }}</h5>
+                <p class="text-muted small mb-2">{{ manager.email }}</p>
+                <span class="badge text-bg-danger">Administrator</span>
+                <hr>
+                <ul class="list-group list-group-borderless text-start">
+                    <li class="list-group-item px-0">
+                        <span class="text-muted small">Member since</span>
+                        <div>{{ manager.createdAt ? manager.createdAt|date('d/m/Y') : '—' }}</div>
+                    </li>
+                    <li class="list-group-item px-0">
+                        <span class="text-muted small">Last login</span>
+                        <div>{{ manager.lastLogin ? manager.lastLogin|date('d/m/Y H:i') : '—' }}</div>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+        {# Right — edit form #}
+        <div class="col-lg-8">
+            <div class="card shadow-sm">
+                <div class="card-header border-bottom">
+                    <h5 class="card-header-title mb-0">Edit Profile Information</h5>
+                </div>
+                <div class="card-body">
+
+                    {% if success %}
+                        <div class="alert alert-success alert-dismissible fade show" role="alert">
+                            {{ success }}
+                            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+                        </div>
+                    {% endif %}
+
+                    <form action="{{ path('app_admin_profile') }}" method="post" class="row g-4" >
+
+                        <div class="col-lg-6">
+                            <label class="form-label">First Name *</label>
+                            <input type="text" name="first_name"
+                                class="form-control {{ errors.first_name is defined ? 'is-invalid' : '' }}"
+                                value="{{ manager.firstName }}" required>
+                            {% if errors.first_name is defined %}
+                                <div class="invalid-feedback d-block">{{ errors.first_name }}</div>
+                            {% endif %}
+                        </div>
+
+                        <div class="col-lg-6">
+                            <label class="form-label">Last Name *</label>
+                            <input type="text" name="last_name"
+                                class="form-control {{ errors.last_name is defined ? 'is-invalid' : '' }}"
+                                value="{{ manager.lastName }}" required>
+                            {% if errors.last_name is defined %}
+                                <div class="invalid-feedback d-block">{{ errors.last_name }}</div>
+                            {% endif %}
+                        </div>
+
+                        <div class="col-12">
+                            <label class="form-label">Email Address *</label>
+                            <input type="email" name="email"
+                                class="form-control {{ errors.email is defined ? 'is-invalid' : '' }}"
+                                value="{{ manager.email }}" required>
+                            {% if errors.email is defined %}
+                                <div class="invalid-feedback d-block">{{ errors.email }}</div>
+                            {% endif %}
+                        </div>
+
+                        <div class="col-12 d-flex justify-content-end">
+                            <button type="submit" class="btn btn-primary mb-0">
+                                <i class="bi bi-check-lg me-1"></i>Save Changes
+                            </button>
+                        </div>
+
+                    </form>
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+{% endblock %}


### PR DESCRIPTION
## What changed
- Removed Symfony UX Turbo and Webpack Encore which were causing form submission and accordion state issues
- Added auto-generated password field with reveal toggle on manager add/edit form
- Refactored ProfileController to use per-field errors array instead of single combined error string
- Replaced role dropdown with Elevate to Admin toggle button

## Files changed
- `src/Traits/FormValidationTrait.php`
- `src/Controller/Admin/ManagerController.php`
- `src/Controller/Admin/ProfileController.php`
- `templates/admin/managers/form.html.twig`
- `templates/admin/profile/index.html.twig`